### PR TITLE
Allowing users to override retry policy

### DIFF
--- a/gcslock.go
+++ b/gcslock.go
@@ -105,6 +105,7 @@ type lockOpts struct {
 	gcsClientOpts []option.ClientOption
 }
 
+// LockOption overrides the default options for the lock.
 type LockOption func(*lockOpts)
 
 // WithRetryPolicy sets the retry policy for the lock. This is used to retry


### PR DESCRIPTION
## Summary

I would like to be able to override the retry policy, because in environments where you have a lot of jitter between retries of the instances trying to acquire the lock they might exaust
retries and give up, and no leader will be elected.

The way I chose to do that is to pass a number of options as functional options ([see more](https://golang.cafe/blog/golang-functional-options-pattern.html)), this way further changes in API (if needed)
will be inconsequential.


